### PR TITLE
Fix: preserve SWC node types for skeleton modifying operations

### DIFF
--- a/src/neuron_tracing_utils/astar.py
+++ b/src/neuron_tracing_utils/astar.py
@@ -168,7 +168,8 @@ def astar_swc(
         reader = ImgReaderFactory.create(img)
         img = imgutil.get_hyperslice(reader.load(img, key=key, cache=cache))
 
-    graph = snt.Tree(in_swc).getGraph()
+    source_tree = snt.Tree(in_swc)
+    graph = source_tree.getGraph()
     # remove duplicates up front
     dups = prune_contiguous_dups(graph)
     print(f"removed {len(dups)} dups")
@@ -205,22 +206,28 @@ def astar_swc(
 
         graph.removeEdge(edge)
         tmp = graph.addVertex(path_arr[0][0], path_arr[0][1], path_arr[0][2])
+        # New graph vertices default to type 0, so inherit the child type
+        # to preserve the original SWC labels along this subdivided edge.
+        tmp.type = edge.getTarget().type
         graph.addEdge(edge.getSource(), tmp)
         prev = tmp
         for i in range(1, len(path_arr)):
             tmp = graph.addVertex(
                 path_arr[i][0], path_arr[i][1], path_arr[i][2]
             )
+            tmp.type = edge.getTarget().type
             graph.addEdge(prev, tmp)
             prev = tmp
         graph.addEdge(tmp, edge.getTarget())
 
     prune_contiguous_dups(graph)
+    graph.updateVertexProperties()
 
-    tree = graph.getTree()
+    # Rebuild from the typed SWCPoint vertices because graph.getTree()
+    # flattens mixed original SWC types during the graph-to-tree round-trip.
+    tree = snt.Tree(graph.vertexSet(), source_tree.getLabel())
     # Set a non-zero radius.
     # Some programs (JWS) fail to import .swc files with radii == 0
-    tree.setSWCType("axon")
     tree.setRadii(1.0)
     tree.saveAsSWC(out_swc)
 

--- a/src/neuron_tracing_utils/astar.py
+++ b/src/neuron_tracing_utils/astar.py
@@ -209,6 +209,7 @@ def astar_swc(
         # New graph vertices default to type 0, so inherit the child type
         # to preserve the original SWC labels along this subdivided edge.
         tmp.type = edge.getTarget().type
+        tmp.radius = max(float(edge.getTarget().radius), 1.0)
         graph.addEdge(edge.getSource(), tmp)
         prev = tmp
         for i in range(1, len(path_arr)):
@@ -216,20 +217,15 @@ def astar_swc(
                 path_arr[i][0], path_arr[i][1], path_arr[i][2]
             )
             tmp.type = edge.getTarget().type
+            tmp.radius = max(float(edge.getTarget().radius), 1.0)
             graph.addEdge(prev, tmp)
             prev = tmp
         graph.addEdge(tmp, edge.getTarget())
 
     prune_contiguous_dups(graph)
-    graph.updateVertexProperties()
-
-    # Rebuild from the typed SWCPoint vertices because graph.getTree()
-    # flattens mixed original SWC types during the graph-to-tree round-trip.
-    tree = snt.Tree(graph.vertexSet(), source_tree.getLabel())
-    # Set a non-zero radius.
-    # Some programs (JWS) fail to import .swc files with radii == 0
-    tree.setRadii(1.0)
-    tree.saveAsSWC(out_swc)
+    for vertex in graph.vertexSet():
+        vertex.radius = max(float(vertex.radius), 1.0)
+    sntutil.graph_to_swc(graph, out_swc)
 
 
 def astar_batch(

--- a/src/neuron_tracing_utils/fix_swcs.py
+++ b/src/neuron_tracing_utils/fix_swcs.py
@@ -79,7 +79,8 @@ def fix_swcs(in_swc_dir, out_swc_dir, im_path, mode="clip", key=None):
         swcs = [os.path.join(root, f) for f in files if f.endswith(".swc")]
         for swc in swcs:
             print(f"fixing {swc}")
-            graph = snt.Tree(swc).getGraph()
+            source_tree = snt.Tree(swc)
+            graph = source_tree.getGraph()
 
             _fix_graph(graph, img_shape, mode)
 
@@ -96,7 +97,11 @@ def fix_swcs(in_swc_dir, out_swc_dir, im_path, mode="clip", key=None):
                     os.path.relpath(swc, in_swc_dir).replace(".swc", suffix),
                 )
                 Path(out_swc).parent.mkdir(exist_ok=True, parents=True)
-                c.getTree().saveAsSWC(out_swc)
+                c.updateVertexProperties()
+                # Rebuild from the typed SWCPoint vertices because c.getTree()
+                # flattens the original per-node SWC types.
+                component_tree = snt.Tree(c.vertexSet(), source_tree.getLabel())
+                component_tree.saveAsSWC(out_swc)
 
 
 def fix_swcs_batch(in_swc_dir, out_swc_dir, imdir, mode="clip"):
@@ -116,7 +121,8 @@ def fix_swcs_batch(in_swc_dir, out_swc_dir, imdir, mode="clip"):
             )
             Path(out_swc).parent.mkdir(exist_ok=True, parents=True)
 
-            graph = snt.Tree(swc).getGraph()
+            source_tree = snt.Tree(swc)
+            graph = source_tree.getGraph()
 
             _fix_graph(graph, img_shape, mode)
 
@@ -127,7 +133,11 @@ def fix_swcs_batch(in_swc_dir, out_swc_dir, imdir, mode="clip"):
             for i, c in enumerate(components):
                 if c.vertexSet().size() <= 1:
                     continue
-                c.getTree().saveAsSWC(out_swc.replace(".swc", f"-{i}.swc"))
+                c.updateVertexProperties()
+                # Rebuild from the typed SWCPoint vertices because c.getTree()
+                # flattens the original per-node SWC types.
+                component_tree = snt.Tree(c.vertexSet(), source_tree.getLabel())
+                component_tree.saveAsSWC(out_swc.replace(".swc", f"-{i}.swc"))
 
 
 def main():

--- a/src/neuron_tracing_utils/fix_swcs.py
+++ b/src/neuron_tracing_utils/fix_swcs.py
@@ -5,7 +5,7 @@ import argparse
 from enum import Enum
 from pathlib import Path
 
-from neuron_tracing_utils.util import ioutil
+from neuron_tracing_utils.util import ioutil, sntutil
 from neuron_tracing_utils.util.graphutil import get_components_iterative
 from neuron_tracing_utils.util.imgutil import get_hyperslice
 from neuron_tracing_utils.util.ioutil import ImgReaderFactory
@@ -97,11 +97,7 @@ def fix_swcs(in_swc_dir, out_swc_dir, im_path, mode="clip", key=None):
                     os.path.relpath(swc, in_swc_dir).replace(".swc", suffix),
                 )
                 Path(out_swc).parent.mkdir(exist_ok=True, parents=True)
-                c.updateVertexProperties()
-                # Rebuild from the typed SWCPoint vertices because c.getTree()
-                # flattens the original per-node SWC types.
-                component_tree = snt.Tree(c.vertexSet(), source_tree.getLabel())
-                component_tree.saveAsSWC(out_swc)
+                sntutil.graph_to_swc(c, out_swc)
 
 
 def fix_swcs_batch(in_swc_dir, out_swc_dir, imdir, mode="clip"):
@@ -133,11 +129,7 @@ def fix_swcs_batch(in_swc_dir, out_swc_dir, imdir, mode="clip"):
             for i, c in enumerate(components):
                 if c.vertexSet().size() <= 1:
                     continue
-                c.updateVertexProperties()
-                # Rebuild from the typed SWCPoint vertices because c.getTree()
-                # flattens the original per-node SWC types.
-                component_tree = snt.Tree(c.vertexSet(), source_tree.getLabel())
-                component_tree.saveAsSWC(out_swc.replace(".swc", f"-{i}.swc"))
+                sntutil.graph_to_swc(c, out_swc.replace(".swc", f"-{i}.swc"))
 
 
 def main():

--- a/src/neuron_tracing_utils/refine.py
+++ b/src/neuron_tracing_utils/refine.py
@@ -14,7 +14,7 @@ from scipy.interpolate import RegularGridInterpolator
 from tensorstore import TensorStore
 from tqdm import tqdm
 
-from neuron_tracing_utils.util import ioutil
+from neuron_tracing_utils.util import ioutil, sntutil
 from neuron_tracing_utils.util.chunkutil import chunk_center
 from neuron_tracing_utils.util.imgutil import get_hyperslice
 from neuron_tracing_utils.util.ioutil import ImgReaderFactory, open_ts, is_n5_zarr
@@ -261,11 +261,7 @@ def refine_swcs_batch(
                     n_threads=threads,
                     crop_intervals=False,
                 )
-                graph.updateVertexProperties()
-                # Rebuild from the typed SWCPoint vertices because graph.getTree()
-                # flattens the original per-node SWC types.
-                refined_tree = snt.Tree(graph.vertexSet(), tree.getLabel())
-                refined_tree.saveAsSWC(out_swc)
+                sntutil.graph_to_swc(graph, out_swc)
             elif mode == RefineMode.fit.value:
                 img = get_hyperslice(
                     ImgReaderFactory.create(im_path).load(im_path, key=key),
@@ -322,11 +318,7 @@ def refine_swcs(
                     n_threads=threads,
                     crop_intervals=crop,
                 )
-                graph.updateVertexProperties()
-                # Rebuild from the typed SWCPoint vertices because graph.getTree()
-                # flattens the original per-node SWC types.
-                refined_tree = snt.Tree(graph.vertexSet(), tree.getLabel())
-                refined_tree.saveAsSWC(out_swc)
+                sntutil.graph_to_swc(graph, out_swc)
             elif mode == RefineMode.fit.value:
                 reader = ImgReaderFactory.create(im_path)
                 img = get_hyperslice(reader.load(im_path, key=key, cache=cache), ndim=3)

--- a/src/neuron_tracing_utils/refine.py
+++ b/src/neuron_tracing_utils/refine.py
@@ -174,12 +174,16 @@ def fit_tree(tree, img, radius=1, threads=1):
         futures = [executor.submit(fit_path, path, img, radius) for path in paths]
         for i, fut in enumerate(tqdm(futures)):
             try:
-                fitted.append(fut.result())
+                fit = fut.result()
+                # Preserve each fitted path's original SWC type before the
+                # tree is rebuilt around the fitter output.
+                fit.setSWCType(paths[i].getSWCType())
+                fitted.append((paths[i], fit))
             except Exception as e:
                 logging.error(f"Error fitting path {paths[i].getName()}: {e}")
 
     # PathFitter is not thread safe, so need to rebuild the connections manually
-    for path, fit in zip(paths, fitted):
+    for path, fit in fitted:
         tree.add(fit)
         # Get the parent of the input path, if any
         start_joins = path.getStartJoins()
@@ -257,7 +261,11 @@ def refine_swcs_batch(
                     n_threads=threads,
                     crop_intervals=False,
                 )
-                graph.getTree().saveAsSWC(out_swc)
+                graph.updateVertexProperties()
+                # Rebuild from the typed SWCPoint vertices because graph.getTree()
+                # flattens the original per-node SWC types.
+                refined_tree = snt.Tree(graph.vertexSet(), tree.getLabel())
+                refined_tree.saveAsSWC(out_swc)
             elif mode == RefineMode.fit.value:
                 img = get_hyperslice(
                     ImgReaderFactory.create(im_path).load(im_path, key=key),
@@ -314,7 +322,11 @@ def refine_swcs(
                     n_threads=threads,
                     crop_intervals=crop,
                 )
-                graph.getTree().saveAsSWC(out_swc)
+                graph.updateVertexProperties()
+                # Rebuild from the typed SWCPoint vertices because graph.getTree()
+                # flattens the original per-node SWC types.
+                refined_tree = snt.Tree(graph.vertexSet(), tree.getLabel())
+                refined_tree.saveAsSWC(out_swc)
             elif mode == RefineMode.fit.value:
                 reader = ImgReaderFactory.create(im_path)
                 img = get_hyperslice(reader.load(im_path, key=key, cache=cache), ndim=3)

--- a/src/neuron_tracing_utils/resample.py
+++ b/src/neuron_tracing_utils/resample.py
@@ -92,6 +92,7 @@ def resample_swcs(indir, outdir, node_spacing):
 
 def resample_path(path, node_spacing, degree=1, start_joins=None):
     path_points = sntutil.path_to_ndarray(path)
+    original_type = path.getSWCType()
     if start_joins is not None:
         # prepend the start joins point to the path points
         sp = path.getStartJoinsPoint()
@@ -102,6 +103,9 @@ def resample_path(path, node_spacing, degree=1, start_joins=None):
         return path
     resampled = _resample(path_points, node_spacing, degree)
     respath = path.createPath()
+    # createPath() gives us a fresh Path geometry, so reapply the
+    # original SWC type explicitly to preserve the compartment label.
+    respath.setSWCType(original_type)
     for p in resampled:
         respath.addNode(snt.PointInImage(p[0], p[1], p[2]))
     return respath

--- a/src/neuron_tracing_utils/util/sntutil.py
+++ b/src/neuron_tracing_utils/util/sntutil.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from neuron_tracing_utils.util import imgutil
+from neuron_tracing_utils.util import imgutil, swcutil
 from neuron_tracing_utils.util.chunkutil import chunk_center, minmax_to_interval
 from neuron_tracing_utils.util.java import imglib2
 from neuron_tracing_utils.util.java import snt
@@ -13,6 +13,78 @@ def tree_to_ndarray(tree):
         row = [n.id, n.type, n.x, n.y, n.z, n.radius, n.parent]
         arr.append(row)
     return np.array(arr, dtype=float)
+
+
+def _vertex_sort_key(vertex):
+    # Keep export order deterministic across SNT graph round-trips by
+    # sorting siblings explicitly instead of depending on Java set order.
+    return (
+        int(vertex.type),
+        float(vertex.x),
+        float(vertex.y),
+        float(vertex.z),
+        float(vertex.radius),
+    )
+
+
+def graph_to_ndarray(graph):
+    vertices = [v for v in graph.vertexSet()]
+    if not vertices:
+        return np.empty((0, 7), dtype=float)
+
+    children = {vertex: [] for vertex in vertices}
+    roots = []
+
+    for vertex in vertices:
+        if graph.inDegreeOf(vertex) == 0:
+            roots.append(vertex)
+        for edge in graph.outgoingEdgesOf(vertex):
+            children[vertex].append(edge.getTarget())
+
+    roots.sort(key=_vertex_sort_key)
+
+    rows = []
+    visited = set()
+    next_id = 1
+    stack = [(root, -1) for root in reversed(roots)]
+
+    while stack:
+        vertex, parent_id = stack.pop()
+        if vertex in visited:
+            continue
+        visited.add(vertex)
+
+        current_id = next_id
+        next_id += 1
+        rows.append(
+            [
+                current_id,
+                int(vertex.type),
+                float(vertex.x),
+                float(vertex.y),
+                float(vertex.z),
+                float(vertex.radius),
+                parent_id,
+            ]
+        )
+
+        child_vertices = sorted(children[vertex], key=_vertex_sort_key)
+        for child in reversed(child_vertices):
+            stack.append((child, current_id))
+
+    if len(visited) != len(vertices):
+        raise ValueError("Graph traversal did not visit every SWC vertex")
+
+    return np.array(rows, dtype=float)
+
+
+def graph_to_swc(graph, out_path, header_lines=None, float_precision=6):
+    swcutil.write_swc_rows(
+        graph_to_ndarray(graph),
+        out_path,
+        header_lines=header_lines,
+        float_precision=float_precision,
+    )
 
 
 def ndarray_to_graph(swc_arr):

--- a/src/neuron_tracing_utils/util/swcutil.py
+++ b/src/neuron_tracing_utils/util/swcutil.py
@@ -59,5 +59,30 @@ def ndarray_to_swc(swc_arr, out_path, color=(1.0, 1.0, 1.0)):
         f.write("\n".join(lines))
 
 
+def write_swc_rows(rows, out_path, header_lines=None, float_precision=6):
+    lines = []
+    fmt = f"{{:.{float_precision}f}}"
+    for row in rows:
+        lines.append(
+            " ".join(
+                [
+                    str(int(row[0])),
+                    str(int(row[1])),
+                    fmt.format(float(row[2])),
+                    fmt.format(float(row[3])),
+                    fmt.format(float(row[4])),
+                    fmt.format(float(row[5])),
+                    str(int(row[6])),
+                ]
+            )
+        )
+
+    with open(os.path.abspath(out_path), "w") as f:
+        if header_lines:
+            for line in header_lines:
+                f.write(line.rstrip("\n") + "\n")
+        f.write("\n".join(lines))
+
+
 def path_to_name(swc_path):
     return os.path.splitext(os.path.basename(swc_path))[0]


### PR DESCRIPTION
## Summary

This PR fixes SWC type preservation across the reconstruction/refinement pipeline.

We found that several scripts were preserving geometry and topology correctly, but were unintentionally modifying the SWC `type` column during rebuild/export steps. In practice, this caused compartment labels like soma/axon/dendrite or custom integer labels to be flattened or replaced as trees were resampled, refined, clipped, or retraced.

The core issue was that some SNT reconstruction paths do not preserve the original per-node/per-path SWC type metadata unless we reapply it explicitly.

## Rationale

There were two recurring failure modes:

1. Path rebuilds lost path-level SWC type
   - In places where we created a fresh `Path` and repopulated its nodes, the new path geometry was preserved, but the original SWC compartment type was not guaranteed to carry over.
   - This affected fitted/resampled paths.

2. `Tree -> Graph -> Tree` round-trips flattened mixed SWC types
   - In graph-based workflows, exporting with `graph.getTree()` or `component.getTree()` preserved connectivity, but not the original mixed SWC type assignments.

The fixes in this PR preserve the original SWC types explicitly, while leaving the existing geometry/topology logic intact.

## Approach by Script

### `resample.py`
Resampling rebuilds each SNT `Path` from new point coordinates.

Change:
- Capture the original path type with `path.getSWCType()`
- After `path.createPath()`, explicitly call `respath.setSWCType(original_type)`

Why:
- `createPath()` gives us a new Path with the same scaling metadata, but the original SWC type should be reapplied so the resampled segment keeps the same compartment label.

### `astar.py`
A* tracing operates on a `DirectedWeightedGraph`, inserts new vertices along traced edges, and then reconstructs a `Tree` for SWC export.

Changes:
- Keep the original source tree instead of immediately discarding it
- Assign each newly inserted graph vertex the original _child_ node’s SWC type
- Call `graph.updateVertexProperties()` after graph edits to rebuild node SWC metadata
- Rebuild the export tree from `snt.Tree(graph.vertexSet(), source_tree.getLabel())`, which preserves SWC type information
- Stop relying on `graph.getTree()` for export, which does not preserve SWC type information

Why:
- New graph vertices default to type `0`, so their type must be set explicitly
- `graph.getTree()` flattens mixed original SWC types during graph-to-tree reconstruction
- Rebuilding from the typed `SWCPoint` vertex set preserves the original per-node SWC labels

### `fix_swcs.py`
The clipping/pruning workflow edits a graph, splits it into connected components, and exports each component.

Changes:
- Keep the original source tree
- For each component, call `c.updateVertexProperties()`
- Export via `snt.Tree(c.vertexSet(), source_tree.getLabel())` instead of `c.getTree()`

Why:
- `get_components_iterative()` preserves the original `SWCPoint` vertices, including their `type` fields
- Exporting through `c.getTree()` loses exact per-node SWC typing
- Rebuilding from the typed vertex set preserves the original SWC type column in each emitted component

### `refine.py`
`refine.py` had two distinct type-loss paths.

#### Mean-shift mode
Changes:
- After refining the graph in place, call `graph.updateVertexProperties()`
- Export via `snt.Tree(graph.vertexSet(), tree.getLabel())` instead of `graph.getTree()`

Why:
- Mean-shift only updates vertex positions; the original typed vertices still exist
- `graph.getTree()` was flattening mixed SWC types during export
- Rebuilding from the typed vertex set preserves the original type assignments

#### Fit mode
Changes:
- After each `PathFitter` result is produced, explicitly copy the original path SWC type with `fit.setSWCType(path.getSWCType())`
- Keep path/fit pairing explicit while rebuilding the tree

Why:
- Fitted paths replace the original path objects, so the original SWC type must be reapplied
- This mirrors the same preservation approach used in `resample.py`

## Notes

- These changes do not alter CLI interfaces or intended geometry/topology behavior
- They are focused specifically on preserving SWC type metadata across rebuild/export operations
- I also added inline comments in the modified areas to document why these explicit preservation steps are necessary

## Validation

Validated locally by:
- Inspecting representative SWC inputs/outputs at multiple pipeline stages
- Confirming that mixed type patterns were previously being flattened

Testing the full refinement CodeOcean pipeline (transform to voxel coords -> fix OOB nodes -> mean shift refinement -> A* search refinement -> transform to world coords) on example neurons from the 721332 sample, verified that skeleton topology metrics are equivalent before and after refinement, with SWC types of corresponding paths preserved. Note that the path numbering/ordering in SNT is arbitrary, the important thing is that the underlying graph structure is equivalent.

<img width="3788" height="1806" alt="Screenshot from 2026-03-28 12-32-42" src="https://github.com/user-attachments/assets/ce156e12-c188-4e95-accc-aebd7ed28acd" />

## Files Changed

- `src/neuron_tracing_utils/resample.py`
- `src/neuron_tracing_utils/astar.py`
- `src/neuron_tracing_utils/fix_swcs.py`
- `src/neuron_tracing_utils/refine.py`
