### PR TITLE
Feat: topology preserving resampler

### DIFF
--- a/src/neuron_tracing_utils/astar.py
+++ b/src/neuron_tracing_utils/astar.py
@@ -168,7 +168,8 @@ def astar_swc(
         reader = ImgReaderFactory.create(img)
         img = imgutil.get_hyperslice(reader.load(img, key=key, cache=cache))
 
-    graph = snt.Tree(in_swc).getGraph()
+    source_tree = snt.Tree(in_swc)
+    graph = source_tree.getGraph()
     # remove duplicates up front
     dups = prune_contiguous_dups(graph)
     print(f"removed {len(dups)} dups")
@@ -205,22 +206,28 @@ def astar_swc(
 
         graph.removeEdge(edge)
         tmp = graph.addVertex(path_arr[0][0], path_arr[0][1], path_arr[0][2])
+        # New graph vertices default to type 0, so inherit the child type
+        # to preserve the original SWC labels along this subdivided edge.
+        tmp.type = edge.getTarget().type
         graph.addEdge(edge.getSource(), tmp)
         prev = tmp
         for i in range(1, len(path_arr)):
             tmp = graph.addVertex(
                 path_arr[i][0], path_arr[i][1], path_arr[i][2]
             )
+            tmp.type = edge.getTarget().type
             graph.addEdge(prev, tmp)
             prev = tmp
         graph.addEdge(tmp, edge.getTarget())
 
     prune_contiguous_dups(graph)
+    graph.updateVertexProperties()
 
-    tree = graph.getTree()
+    # Rebuild from the typed SWCPoint vertices because graph.getTree()
+    # flattens mixed original SWC types during the graph-to-tree round-trip.
+    tree = snt.Tree(graph.vertexSet(), source_tree.getLabel())
     # Set a non-zero radius.
     # Some programs (JWS) fail to import .swc files with radii == 0
-    tree.setSWCType("axon")
     tree.setRadii(1.0)
     tree.saveAsSWC(out_swc)
 

--- a/src/neuron_tracing_utils/astar.py
+++ b/src/neuron_tracing_utils/astar.py
@@ -209,6 +209,7 @@ def astar_swc(
         # New graph vertices default to type 0, so inherit the child type
         # to preserve the original SWC labels along this subdivided edge.
         tmp.type = edge.getTarget().type
+        tmp.radius = max(float(edge.getTarget().radius), 1.0)
         graph.addEdge(edge.getSource(), tmp)
         prev = tmp
         for i in range(1, len(path_arr)):
@@ -216,20 +217,15 @@ def astar_swc(
                 path_arr[i][0], path_arr[i][1], path_arr[i][2]
             )
             tmp.type = edge.getTarget().type
+            tmp.radius = max(float(edge.getTarget().radius), 1.0)
             graph.addEdge(prev, tmp)
             prev = tmp
         graph.addEdge(tmp, edge.getTarget())
 
     prune_contiguous_dups(graph)
-    graph.updateVertexProperties()
-
-    # Rebuild from the typed SWCPoint vertices because graph.getTree()
-    # flattens mixed original SWC types during the graph-to-tree round-trip.
-    tree = snt.Tree(graph.vertexSet(), source_tree.getLabel())
-    # Set a non-zero radius.
-    # Some programs (JWS) fail to import .swc files with radii == 0
-    tree.setRadii(1.0)
-    tree.saveAsSWC(out_swc)
+    for vertex in graph.vertexSet():
+        vertex.radius = max(float(vertex.radius), 1.0)
+    sntutil.graph_to_swc(graph, out_swc)
 
 
 def astar_batch(

--- a/src/neuron_tracing_utils/fix_swcs.py
+++ b/src/neuron_tracing_utils/fix_swcs.py
@@ -79,7 +79,8 @@ def fix_swcs(in_swc_dir, out_swc_dir, im_path, mode="clip", key=None):
         swcs = [os.path.join(root, f) for f in files if f.endswith(".swc")]
         for swc in swcs:
             print(f"fixing {swc}")
-            graph = snt.Tree(swc).getGraph()
+            source_tree = snt.Tree(swc)
+            graph = source_tree.getGraph()
 
             _fix_graph(graph, img_shape, mode)
 
@@ -96,7 +97,11 @@ def fix_swcs(in_swc_dir, out_swc_dir, im_path, mode="clip", key=None):
                     os.path.relpath(swc, in_swc_dir).replace(".swc", suffix),
                 )
                 Path(out_swc).parent.mkdir(exist_ok=True, parents=True)
-                c.getTree().saveAsSWC(out_swc)
+                c.updateVertexProperties()
+                # Rebuild from the typed SWCPoint vertices because c.getTree()
+                # flattens the original per-node SWC types.
+                component_tree = snt.Tree(c.vertexSet(), source_tree.getLabel())
+                component_tree.saveAsSWC(out_swc)
 
 
 def fix_swcs_batch(in_swc_dir, out_swc_dir, imdir, mode="clip"):
@@ -116,7 +121,8 @@ def fix_swcs_batch(in_swc_dir, out_swc_dir, imdir, mode="clip"):
             )
             Path(out_swc).parent.mkdir(exist_ok=True, parents=True)
 
-            graph = snt.Tree(swc).getGraph()
+            source_tree = snt.Tree(swc)
+            graph = source_tree.getGraph()
 
             _fix_graph(graph, img_shape, mode)
 
@@ -127,7 +133,11 @@ def fix_swcs_batch(in_swc_dir, out_swc_dir, imdir, mode="clip"):
             for i, c in enumerate(components):
                 if c.vertexSet().size() <= 1:
                     continue
-                c.getTree().saveAsSWC(out_swc.replace(".swc", f"-{i}.swc"))
+                c.updateVertexProperties()
+                # Rebuild from the typed SWCPoint vertices because c.getTree()
+                # flattens the original per-node SWC types.
+                component_tree = snt.Tree(c.vertexSet(), source_tree.getLabel())
+                component_tree.saveAsSWC(out_swc.replace(".swc", f"-{i}.swc"))
 
 
 def main():

--- a/src/neuron_tracing_utils/fix_swcs.py
+++ b/src/neuron_tracing_utils/fix_swcs.py
@@ -5,7 +5,7 @@ import argparse
 from enum import Enum
 from pathlib import Path
 
-from neuron_tracing_utils.util import ioutil
+from neuron_tracing_utils.util import ioutil, sntutil
 from neuron_tracing_utils.util.graphutil import get_components_iterative
 from neuron_tracing_utils.util.imgutil import get_hyperslice
 from neuron_tracing_utils.util.ioutil import ImgReaderFactory
@@ -97,11 +97,7 @@ def fix_swcs(in_swc_dir, out_swc_dir, im_path, mode="clip", key=None):
                     os.path.relpath(swc, in_swc_dir).replace(".swc", suffix),
                 )
                 Path(out_swc).parent.mkdir(exist_ok=True, parents=True)
-                c.updateVertexProperties()
-                # Rebuild from the typed SWCPoint vertices because c.getTree()
-                # flattens the original per-node SWC types.
-                component_tree = snt.Tree(c.vertexSet(), source_tree.getLabel())
-                component_tree.saveAsSWC(out_swc)
+                sntutil.graph_to_swc(c, out_swc)
 
 
 def fix_swcs_batch(in_swc_dir, out_swc_dir, imdir, mode="clip"):
@@ -133,11 +129,7 @@ def fix_swcs_batch(in_swc_dir, out_swc_dir, imdir, mode="clip"):
             for i, c in enumerate(components):
                 if c.vertexSet().size() <= 1:
                     continue
-                c.updateVertexProperties()
-                # Rebuild from the typed SWCPoint vertices because c.getTree()
-                # flattens the original per-node SWC types.
-                component_tree = snt.Tree(c.vertexSet(), source_tree.getLabel())
-                component_tree.saveAsSWC(out_swc.replace(".swc", f"-{i}.swc"))
+                sntutil.graph_to_swc(c, out_swc.replace(".swc", f"-{i}.swc"))
 
 
 def main():

--- a/src/neuron_tracing_utils/refine.py
+++ b/src/neuron_tracing_utils/refine.py
@@ -14,7 +14,7 @@ from scipy.interpolate import RegularGridInterpolator
 from tensorstore import TensorStore
 from tqdm import tqdm
 
-from neuron_tracing_utils.util import ioutil
+from neuron_tracing_utils.util import ioutil, sntutil
 from neuron_tracing_utils.util.chunkutil import chunk_center
 from neuron_tracing_utils.util.imgutil import get_hyperslice
 from neuron_tracing_utils.util.ioutil import ImgReaderFactory, open_ts, is_n5_zarr
@@ -261,11 +261,7 @@ def refine_swcs_batch(
                     n_threads=threads,
                     crop_intervals=False,
                 )
-                graph.updateVertexProperties()
-                # Rebuild from the typed SWCPoint vertices because graph.getTree()
-                # flattens the original per-node SWC types.
-                refined_tree = snt.Tree(graph.vertexSet(), tree.getLabel())
-                refined_tree.saveAsSWC(out_swc)
+                sntutil.graph_to_swc(graph, out_swc)
             elif mode == RefineMode.fit.value:
                 img = get_hyperslice(
                     ImgReaderFactory.create(im_path).load(im_path, key=key),
@@ -322,11 +318,7 @@ def refine_swcs(
                     n_threads=threads,
                     crop_intervals=crop,
                 )
-                graph.updateVertexProperties()
-                # Rebuild from the typed SWCPoint vertices because graph.getTree()
-                # flattens the original per-node SWC types.
-                refined_tree = snt.Tree(graph.vertexSet(), tree.getLabel())
-                refined_tree.saveAsSWC(out_swc)
+                sntutil.graph_to_swc(graph, out_swc)
             elif mode == RefineMode.fit.value:
                 reader = ImgReaderFactory.create(im_path)
                 img = get_hyperslice(reader.load(im_path, key=key, cache=cache), ndim=3)

--- a/src/neuron_tracing_utils/refine.py
+++ b/src/neuron_tracing_utils/refine.py
@@ -174,12 +174,16 @@ def fit_tree(tree, img, radius=1, threads=1):
         futures = [executor.submit(fit_path, path, img, radius) for path in paths]
         for i, fut in enumerate(tqdm(futures)):
             try:
-                fitted.append(fut.result())
+                fit = fut.result()
+                # Preserve each fitted path's original SWC type before the
+                # tree is rebuilt around the fitter output.
+                fit.setSWCType(paths[i].getSWCType())
+                fitted.append((paths[i], fit))
             except Exception as e:
                 logging.error(f"Error fitting path {paths[i].getName()}: {e}")
 
     # PathFitter is not thread safe, so need to rebuild the connections manually
-    for path, fit in zip(paths, fitted):
+    for path, fit in fitted:
         tree.add(fit)
         # Get the parent of the input path, if any
         start_joins = path.getStartJoins()
@@ -257,7 +261,11 @@ def refine_swcs_batch(
                     n_threads=threads,
                     crop_intervals=False,
                 )
-                graph.getTree().saveAsSWC(out_swc)
+                graph.updateVertexProperties()
+                # Rebuild from the typed SWCPoint vertices because graph.getTree()
+                # flattens the original per-node SWC types.
+                refined_tree = snt.Tree(graph.vertexSet(), tree.getLabel())
+                refined_tree.saveAsSWC(out_swc)
             elif mode == RefineMode.fit.value:
                 img = get_hyperslice(
                     ImgReaderFactory.create(im_path).load(im_path, key=key),
@@ -314,7 +322,11 @@ def refine_swcs(
                     n_threads=threads,
                     crop_intervals=crop,
                 )
-                graph.getTree().saveAsSWC(out_swc)
+                graph.updateVertexProperties()
+                # Rebuild from the typed SWCPoint vertices because graph.getTree()
+                # flattens the original per-node SWC types.
+                refined_tree = snt.Tree(graph.vertexSet(), tree.getLabel())
+                refined_tree.saveAsSWC(out_swc)
             elif mode == RefineMode.fit.value:
                 reader = ImgReaderFactory.create(im_path)
                 img = get_hyperslice(reader.load(im_path, key=key, cache=cache), ndim=3)

--- a/src/neuron_tracing_utils/resample.py
+++ b/src/neuron_tracing_utils/resample.py
@@ -12,6 +12,160 @@ from neuron_tracing_utils.util import sntutil, swcutil
 from neuron_tracing_utils.util.java import snt
 
 
+def _point_to_ndarray(point):
+    return np.array([point.getX(), point.getY(), point.getZ()], dtype=float)
+
+
+def _dedupe_consecutive_points(points):
+    if len(points) < 2:
+        return points.copy()
+
+    keep = np.ones(len(points), dtype=bool)
+    keep[1:] = np.any(np.diff(points, axis=0) != 0, axis=1)
+    return points[keep]
+
+
+def _cumulative_lengths(points):
+    if len(points) < 2:
+        return np.array([], dtype=float), np.array([0.0], dtype=float)
+
+    diffs = np.diff(points, axis=0)
+    seg_lengths = np.linalg.norm(diffs, axis=1)
+    cumulative = np.concatenate(([0.0], np.cumsum(seg_lengths)))
+    return seg_lengths, cumulative
+
+
+def _point_at_arc_length(points, seg_lengths, cumulative, arc_length):
+    if len(points) == 1:
+        return points[0].copy()
+    if arc_length <= 0:
+        return points[0].copy()
+    if arc_length >= cumulative[-1]:
+        return points[-1].copy()
+
+    seg_idx = int(np.searchsorted(cumulative, arc_length, side="right") - 1)
+    seg_len = seg_lengths[seg_idx]
+    if seg_len == 0:
+        return points[seg_idx].copy()
+
+    offset = arc_length - cumulative[seg_idx]
+    t = offset / seg_len
+    return points[seg_idx] + t * (points[seg_idx + 1] - points[seg_idx])
+
+
+def _project_point_onto_polyline(points, query):
+    query = np.asarray(query, dtype=float)
+    if len(points) == 1:
+        return 0.0, points[0].copy(), float(np.linalg.norm(points[0] - query))
+
+    seg_lengths, cumulative = _cumulative_lengths(points)
+    best_dist = float("inf")
+    best_arc = 0.0
+    best_point = points[0].copy()
+
+    for idx, seg_len in enumerate(seg_lengths):
+        start = points[idx]
+        end = points[idx + 1]
+        segment = end - start
+        if seg_len == 0:
+            proj = start
+            t = 0.0
+        else:
+            t = np.dot(query - start, segment) / np.dot(segment, segment)
+            t = float(np.clip(t, 0.0, 1.0))
+            proj = start + t * segment
+
+        dist = float(np.linalg.norm(query - proj))
+        if dist < best_dist:
+            best_dist = dist
+            best_arc = cumulative[idx] + t * seg_len
+            best_point = proj
+
+    return best_arc, best_point, best_dist
+
+
+def _slice_polyline(points, seg_lengths, cumulative, start_arc, end_arc):
+    start_point = _point_at_arc_length(points, seg_lengths, cumulative, start_arc)
+    end_point = _point_at_arc_length(points, seg_lengths, cumulative, end_arc)
+    interior_mask = (cumulative > start_arc) & (cumulative < end_arc)
+    interior_points = points[interior_mask]
+    segment = np.vstack((start_point, interior_points, end_point))
+    return _dedupe_consecutive_points(segment)
+
+
+def _normalize_anchor_positions(anchor_positions, total_length, tol=1e-6):
+    if not anchor_positions:
+        return [], []
+
+    clipped = [float(np.clip(pos, 0.0, total_length)) for pos in anchor_positions]
+    order = sorted(range(len(clipped)), key=lambda idx: clipped[idx])
+
+    unique_positions = []
+    input_to_unique = [0] * len(clipped)
+    for idx in order:
+        position = clipped[idx]
+        if not unique_positions or abs(position - unique_positions[-1]) > tol:
+            unique_positions.append(position)
+        input_to_unique[idx] = len(unique_positions) - 1
+
+    return unique_positions, input_to_unique
+
+
+def _resample_polyline_preserving_anchors(
+    points, node_spacing, degree=1, anchor_positions=None
+):
+    points = _dedupe_consecutive_points(np.asarray(points, dtype=float))
+    if len(points) == 0:
+        return points, []
+
+    anchor_positions = [] if anchor_positions is None else list(anchor_positions)
+    if len(points) == 1:
+        return points.copy(), [0] * len(anchor_positions)
+
+    seg_lengths, cumulative = _cumulative_lengths(points)
+    total_length = cumulative[-1]
+    unique_anchors, input_to_unique = _normalize_anchor_positions(
+        anchor_positions, total_length
+    )
+
+    boundaries = [0.0]
+    boundaries.extend(
+        anchor for anchor in unique_anchors if 0.0 < anchor < total_length
+    )
+    boundaries.append(total_length)
+
+    output = []
+    boundary_output_indices = {}
+    for segment_idx, (start_arc, end_arc) in enumerate(zip(boundaries, boundaries[1:])):
+        segment = _slice_polyline(
+            points, seg_lengths, cumulative, start_arc, end_arc
+        )
+        resampled = _resample(segment, node_spacing, degree)
+        if len(resampled) == 0:
+            continue
+
+        # Keep anchor coordinates exact, even when interpolation introduces
+        # tiny floating-point drift.
+        resampled[0] = segment[0]
+        resampled[-1] = segment[-1]
+
+        if segment_idx == 0:
+            output = resampled.tolist()
+            start_idx = 0
+        else:
+            start_idx = len(output) - 1
+            output.extend(resampled[1:].tolist())
+
+        boundary_output_indices[start_arc] = start_idx
+        boundary_output_indices[end_arc] = len(output) - 1
+
+    anchor_output_indices = [
+        boundary_output_indices[unique_anchors[unique_idx]]
+        for unique_idx in input_to_unique
+    ]
+    return np.asarray(output, dtype=float), anchor_output_indices
+
+
 def resample_tree(tree, node_spacing, degree=1):
     """
     Performs in-place resampling of a Tree.
@@ -36,8 +190,11 @@ def resample_tree(tree, node_spacing, degree=1):
     paths = list(tree.list())
     for path in paths:
         start_joins = path.getStartJoins()
+        children = list(path.getChildren())
         # Get a resampled version of the path
-        resampled = resample_path(path, node_spacing, degree, start_joins)
+        resampled, child_node_indices = resample_path(
+            path, node_spacing, degree, start_joins, children
+        )
         # Add it to the tree.
         # Note we have not specified any connections yet,
         # so this is just a single un-branched segment.
@@ -52,19 +209,20 @@ def resample_tree(tree, node_spacing, degree=1):
             # Replace with the resampled version
             resampled.setStartJoin(start_joins, start_joins_point)
         # Now swap the connections for any children of the input path
-        # Wrap in a Python list to avoid a ConcurrentModificationException
-        children = list(path.getChildren())
         for child in children:
-            # Get the point of connection on the input path
-            start_joins_point = child.getStartJoinsPoint()
-            # Find the closest point on the resampled version, since
-            # the node coordinates are different
-            closest_idx = resampled.indexNearestTo(
-                start_joins_point.getX(),
-                start_joins_point.getY(),
-                start_joins_point.getZ(),
-                float("inf"),  # within this distance
-            )
+            closest_idx = child_node_indices.get(child)
+            if closest_idx is None:
+                start_joins_point = child.getStartJoinsPoint()
+                logging.warning(
+                    "Falling back to nearest-node join remap for child %s",
+                    child.getName(),
+                )
+                closest_idx = resampled.indexNearestTo(
+                    start_joins_point.getX(),
+                    start_joins_point.getY(),
+                    start_joins_point.getZ(),
+                    float("inf"),
+                )
             closest_point = resampled.getNode(closest_idx)
             # Now unlink the child from the input path
             child.unsetStartJoin()
@@ -90,36 +248,57 @@ def resample_swcs(indir, outdir, node_spacing):
             tree.saveAsSWC(out_swc)
 
 
-def resample_path(path, node_spacing, degree=1, start_joins=None):
-    path_points = sntutil.path_to_ndarray(path)
+def resample_path(path, node_spacing, degree=1, start_joins=None, children=None):
+    path_points = sntutil.path_to_ndarray(path).astype(float)
     original_type = path.getSWCType()
+    children = [] if children is None else list(children)
+
     if start_joins is not None:
         # prepend the start joins point to the path points
-        sp = path.getStartJoinsPoint()
-        path_points = np.vstack(
-            (np.array([sp.getX(), sp.getY(), sp.getZ()]), path_points)
-        )
-    if len(path_points) < 2:
-        return path
-    resampled = _resample(path_points, node_spacing, degree)
+        path_points = np.vstack((_point_to_ndarray(path.getStartJoinsPoint()), path_points))
+
+    anchor_positions = []
+    for child in children:
+        start_point = _point_to_ndarray(child.getStartJoinsPoint())
+        arc_length, _, distance = _project_point_onto_polyline(path_points, start_point)
+        if distance > 1e-3:
+            logging.debug(
+                "Projected child join %.6f units onto parent path for %s",
+                distance,
+                child.getName(),
+            )
+        anchor_positions.append(arc_length)
+
+    resampled, anchor_node_indices = _resample_polyline_preserving_anchors(
+        path_points,
+        node_spacing,
+        degree,
+        anchor_positions=anchor_positions,
+    )
     respath = path.createPath()
     # createPath() gives us a fresh Path geometry, so reapply the
     # original SWC type explicitly to preserve the compartment label.
     respath.setSWCType(original_type)
     for p in resampled:
         respath.addNode(snt.PointInImage(p[0], p[1], p[2]))
-    return respath
+
+    child_node_map = {
+        child: node_idx for child, node_idx in zip(children, anchor_node_indices)
+    }
+    return respath, child_node_map
 
 
 def _resample(points, node_spacing, degree=1):
-    # remove duplicate nodes
-    _, ind = np.unique(points, axis=0, return_index=True)
-    # Maintain input order
-    points = points[np.sort(ind)]
+    points = _dedupe_consecutive_points(np.asarray(points, dtype=float))
+    if len(points) < 2:
+        return points.copy()
     # Determine number of query points and their parameters
     diff = np.diff(points, axis=0)
     ss = np.power(diff, 2).sum(axis=1)
     length = np.sqrt(ss).sum()
+    if length == 0:
+        return points[[0]].copy()
+
     quo, rem = divmod(length, node_spacing)
     samples = np.linspace(0, node_spacing * quo, int(quo + 1), endpoint=True)
     if rem != 0:
@@ -127,8 +306,11 @@ def _resample(points, node_spacing, degree=1):
     # Queries along the spline must be in range [0, 1]
     query_points = np.clip(samples / max(samples), a_min=0.0, a_max=1.0)
     # Create spline points and evaluate at queries
-    tck, _ = splprep(points.T, k=degree)
+    spline_degree = min(degree, len(points) - 1)
+    tck, _ = splprep(points.T, k=spline_degree)
     result = np.array(splev(query_points, tck)).T
+    result[0] = points[0]
+    result[-1] = points[-1]
     return result
 
 

--- a/src/neuron_tracing_utils/resample.py
+++ b/src/neuron_tracing_utils/resample.py
@@ -92,6 +92,7 @@ def resample_swcs(indir, outdir, node_spacing):
 
 def resample_path(path, node_spacing, degree=1, start_joins=None):
     path_points = sntutil.path_to_ndarray(path)
+    original_type = path.getSWCType()
     if start_joins is not None:
         # prepend the start joins point to the path points
         sp = path.getStartJoinsPoint()
@@ -102,6 +103,9 @@ def resample_path(path, node_spacing, degree=1, start_joins=None):
         return path
     resampled = _resample(path_points, node_spacing, degree)
     respath = path.createPath()
+    # createPath() gives us a fresh Path geometry, so reapply the
+    # original SWC type explicitly to preserve the compartment label.
+    respath.setSWCType(original_type)
     for p in resampled:
         respath.addNode(snt.PointInImage(p[0], p[1], p[2]))
     return respath

--- a/src/neuron_tracing_utils/util/sntutil.py
+++ b/src/neuron_tracing_utils/util/sntutil.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from neuron_tracing_utils.util import imgutil
+from neuron_tracing_utils.util import imgutil, swcutil
 from neuron_tracing_utils.util.chunkutil import chunk_center, minmax_to_interval
 from neuron_tracing_utils.util.java import imglib2
 from neuron_tracing_utils.util.java import snt
@@ -13,6 +13,78 @@ def tree_to_ndarray(tree):
         row = [n.id, n.type, n.x, n.y, n.z, n.radius, n.parent]
         arr.append(row)
     return np.array(arr, dtype=float)
+
+
+def _vertex_sort_key(vertex):
+    # Keep export order deterministic across SNT graph round-trips by
+    # sorting siblings explicitly instead of depending on Java set order.
+    return (
+        int(vertex.type),
+        float(vertex.x),
+        float(vertex.y),
+        float(vertex.z),
+        float(vertex.radius),
+    )
+
+
+def graph_to_ndarray(graph):
+    vertices = [v for v in graph.vertexSet()]
+    if not vertices:
+        return np.empty((0, 7), dtype=float)
+
+    children = {vertex: [] for vertex in vertices}
+    roots = []
+
+    for vertex in vertices:
+        if graph.inDegreeOf(vertex) == 0:
+            roots.append(vertex)
+        for edge in graph.outgoingEdgesOf(vertex):
+            children[vertex].append(edge.getTarget())
+
+    roots.sort(key=_vertex_sort_key)
+
+    rows = []
+    visited = set()
+    next_id = 1
+    stack = [(root, -1) for root in reversed(roots)]
+
+    while stack:
+        vertex, parent_id = stack.pop()
+        if vertex in visited:
+            continue
+        visited.add(vertex)
+
+        current_id = next_id
+        next_id += 1
+        rows.append(
+            [
+                current_id,
+                int(vertex.type),
+                float(vertex.x),
+                float(vertex.y),
+                float(vertex.z),
+                float(vertex.radius),
+                parent_id,
+            ]
+        )
+
+        child_vertices = sorted(children[vertex], key=_vertex_sort_key)
+        for child in reversed(child_vertices):
+            stack.append((child, current_id))
+
+    if len(visited) != len(vertices):
+        raise ValueError("Graph traversal did not visit every SWC vertex")
+
+    return np.array(rows, dtype=float)
+
+
+def graph_to_swc(graph, out_path, header_lines=None, float_precision=6):
+    swcutil.write_swc_rows(
+        graph_to_ndarray(graph),
+        out_path,
+        header_lines=header_lines,
+        float_precision=float_precision,
+    )
 
 
 def ndarray_to_graph(swc_arr):

--- a/src/neuron_tracing_utils/util/swcutil.py
+++ b/src/neuron_tracing_utils/util/swcutil.py
@@ -59,5 +59,30 @@ def ndarray_to_swc(swc_arr, out_path, color=(1.0, 1.0, 1.0)):
         f.write("\n".join(lines))
 
 
+def write_swc_rows(rows, out_path, header_lines=None, float_precision=6):
+    lines = []
+    fmt = f"{{:.{float_precision}f}}"
+    for row in rows:
+        lines.append(
+            " ".join(
+                [
+                    str(int(row[0])),
+                    str(int(row[1])),
+                    fmt.format(float(row[2])),
+                    fmt.format(float(row[3])),
+                    fmt.format(float(row[4])),
+                    fmt.format(float(row[5])),
+                    str(int(row[6])),
+                ]
+            )
+        )
+
+    with open(os.path.abspath(out_path), "w") as f:
+        if header_lines:
+            for line in header_lines:
+                f.write(line.rstrip("\n") + "\n")
+        f.write("\n".join(lines))
+
+
 def path_to_name(swc_path):
     return os.path.splitext(os.path.basename(swc_path))[0]

--- a/tests/test_resample.py
+++ b/tests/test_resample.py
@@ -1,0 +1,71 @@
+import unittest
+
+import numpy as np
+
+from neuron_tracing_utils.resample import (
+    _dedupe_consecutive_points,
+    _resample_polyline_preserving_anchors,
+)
+
+
+class ResampleHelpersTest(unittest.TestCase):
+    def test_preserves_distinct_anchor_nodes(self):
+        points = np.array(
+            [
+                [0.0, 0.0, 0.0],
+                [10.0, 0.0, 0.0],
+                [20.0, 0.0, 0.0],
+                [30.0, 0.0, 0.0],
+                [40.0, 0.0, 0.0],
+            ]
+        )
+
+        resampled, anchor_indices = _resample_polyline_preserving_anchors(
+            points,
+            node_spacing=20.0,
+            degree=1,
+            anchor_positions=[11.0, 19.0],
+        )
+
+        np.testing.assert_allclose(resampled[anchor_indices[0]], [11.0, 0.0, 0.0])
+        np.testing.assert_allclose(resampled[anchor_indices[1]], [19.0, 0.0, 0.0])
+        self.assertNotEqual(anchor_indices[0], anchor_indices[1])
+
+    def test_duplicate_anchors_share_the_same_output_node(self):
+        points = np.array(
+            [
+                [0.0, 0.0, 0.0],
+                [10.0, 0.0, 0.0],
+                [20.0, 0.0, 0.0],
+                [30.0, 0.0, 0.0],
+            ]
+        )
+
+        resampled, anchor_indices = _resample_polyline_preserving_anchors(
+            points,
+            node_spacing=20.0,
+            degree=1,
+            anchor_positions=[11.0, 11.0, 19.0],
+        )
+
+        self.assertEqual(anchor_indices[0], anchor_indices[1])
+        self.assertNotEqual(anchor_indices[0], anchor_indices[2])
+        np.testing.assert_allclose(resampled[anchor_indices[0]], [11.0, 0.0, 0.0])
+
+    def test_keeps_non_consecutive_repeated_points(self):
+        points = np.array(
+            [
+                [0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0],
+            ]
+        )
+
+        deduped = _dedupe_consecutive_points(points)
+
+        self.assertEqual(len(deduped), 3)
+        np.testing.assert_allclose(deduped, points)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`resample.py` reattaches each child branch to the nearest node on the newly resampled parent path. Because we only keep nodes at uniform spacing, two distinct original join locations can snap to the same sampled node and collapse one branch point, changing topology of the original skeleton.

Instead of resampling a whole path first and then asking “which new node is closest to each child attachment?”, the new code turns each child attachment into a fixed anchor along the original path and forces those anchors to survive resampling as explicit nodes, preventing nearby branch points from collapsing. This also has the benefit of preserving the exact locations where annotators place fork points, which is biologically meaningful.

**What Changed**
The old flow in `resample.py` was:

1. Resample one whole `Path`.
2. For each child, find the nearest node on the new path.
3. Reattach the child there.

The problem is that if two child joins are near each other, both can snap to the same new node.

The new flow is:

1. Find where each child join sits along the original path.
2. Treat those join locations as anchors.
3. Split the path at those anchors.
4. Resample each piece separately.
5. Stitch the pieces back together.
6. Reattach each child to its exact preserved anchor node.

**The Math**
The core coordinate system is arc length.

For a path with points `p0, p1, ..., pn`, we compute cumulative distances:

```text
s0 = 0
s1 = ||p1 - p0||
s2 = ||p1 - p0|| + ||p2 - p1||
...
```
Once we have that, every important location on the path can be described by a single scalar `s`, meaning “distance traveled from the start of the path.”

**Point Projection**
We take a join point and convert it into its arc-length position `s`.

For each segment `[a, b]` of the polyline, we compute the closest point to the query:

```text
t = clamp(((q - a) · (b - a)) / ||b - a||^2, 0, 1)
proj = a + t (b - a)
```

Then we pick the segment whose projected point is closest and turn that into a global arc length.

In SNT, the join point (usually) is already an exact node, so projection just lands exactly on that node. But conceptually this is the right operation because it says “where along the original path is this attachment?”, not “which original node is nearest?”

**The Key Helper**
`_resample_polyline_preserving_anchors()` is the heart of the change.

It does this:

1. Compute total path length.
2. Normalize and deduplicate anchor positions.
3. Build boundaries: `[0, anchor1, anchor2, ..., total_length]`.
4. Slice the original polyline between each consecutive pair of boundaries.
5. Resample each slice independently.
6. Force the first and last point of each slice to be exact.
7. Stitch the slices back together.

That “force the endpoints to be exact” part is crucial. It guarantees every anchor survives as an explicit node.

**Why This Fixes Branch Merging**
Take a 1D toy path from `0` to `40` with target spacing `20`, and suppose two branch joins are at `11` and `19`.

Old behavior:
- resample whole path
- new nodes are roughly `0, 20, 40`
- both joins map to `20`
- branch points merge

New behavior:
- anchors are `11` and `19`
- split into `[0,11]`, `[11,19]`, `[19,40]`
- each piece is resampled separately
- stitched result must contain nodes at `11` and `19`

So even though `11` and `19` are closer than the target spacing, they remain distinct topology nodes.

**How The Tree Rewiring Changed**
In `resample_path()`, we now return two things:
- the new resampled `Path`
- a map from each child path to the exact node index of its preserved anchor

Then `resample_tree()` uses that exact node index when reconnecting the child, instead of calling `indexNearestTo(...)`.

That is the behavioral fix.

**Why We Also Changed `_resample`**
`_resample()` got a few safety changes:
- only consecutive duplicates are removed
- zero-length paths are handled explicitly
- spline degree is capped at `len(points) - 1`
- endpoints are overwritten with the exact originals

These are mostly guardrails so the anchor-preserving logic stays stable.

**How The Tests Map To The Idea**
The new tests in `test_resample.py` check exactly the important cases:

- anchors at `11` and `19` stay as two different nodes
- duplicate anchors map to the same node
- non-consecutive repeated points are not accidentally deleted